### PR TITLE
Local runnability report: LTX-2.5 vs LTX-2.3 on 16 GB M2

### DIFF
--- a/researches/local_model_reports/README.md
+++ b/researches/local_model_reports/README.md
@@ -11,6 +11,7 @@ Notes and shortlists for local models (Metal / MLX / llama.cpp / Ollama / audio 
 | [report-2026-08-02-video-ai-news.md](./report-2026-08-02-video-ai-news.md) | video [OrcBSpADCGk](https://youtu.be/OrcBSpADCGk) (as of 2026-08-02) | Runnability on 16 GB M2 for every model named in that AI-news video; deep dive on CrisperWhisper + Instella |
 | [report-2026-08-16-video-ai-news.md](./report-2026-08-16-video-ai-news.md) | video [62HSUsS0ypo](https://www.youtube.com/watch?v=62HSUsS0ypo) (as of 2026-08-16) | Runnability on 16 GB M2 for every model named in that AI-news video; IndexTTS 2.5 + Qwen3.8-27B vs the rest |
 | [report-2026-08-23-video-ai-news.md](./report-2026-08-23-video-ai-news.md) | video [rQ4yX5qNYdY](https://youtu.be/rQ4yX5qNYdY) (as of 2026-08-23) | Runnability on 16 GB M2 for every model named in that AI-news video; Audio8-TTS 0.1B + Ornith 1.5 9B vs the rest |
+| [report-2026-08-25-ltx-2.5.md](./report-2026-08-25-ltx-2.5.md) | as of 2026-08-25 | **LTX-2.5** deep dive vs **LTX-2.3** on the 16 GB M2; why the “16 GB VRAM” floor is not 16 GB unified |
 
 ## Scripts
 

--- a/researches/local_model_reports/report-2026-08-25-ltx-2.5.md
+++ b/researches/local_model_reports/report-2026-08-25-ltx-2.5.md
@@ -1,0 +1,252 @@
+# Local Runnability: LTX-2.5 vs LTX-2.3
+
+**Compiled:** 2026-08-25  
+**Topic:** [LTX-2.5](https://ltx.io/model/ltx-2-5) (Lightricks / LTX), with a side-by-side against [LTX-2.3](https://huggingface.co/Lightricks/LTX-2.3) on this machine  
+**Hardware target:** Apple **M2 MacBook Pro, 16 GB unified memory** (same machine as [report-2026-07-17](./report-2026-07-17.md), [report-2026-07-27-music](./report-2026-07-27-music.md), [report-2026-08-02-video-ai-news](./report-2026-08-02-video-ai-news.md), [report-2026-08-16-video-ai-news](./report-2026-08-16-video-ai-news.md), and [report-2026-08-23-video-ai-news](./report-2026-08-23-video-ai-news.md))  
+**Stack assumption:** Metal / MLX / llama.cpp / Ollama / PyTorch-MPS — **no CUDA**
+
+The [2026-08-16 video report](./report-2026-08-16-video-ai-news.md) already marked LTX-2.5 as **open weights, not this machine**. This note is the dedicated follow-up: what 2.5 actually is, how it differs from 2.3, and why the marketing “16 GB VRAM” floor is not the same as 16 GB unified on an M2.
+
+## Your real memory budget (unchanged)
+
+16 GB unified ≠ 16 GB for the model.
+
+- macOS + browser + IDE typically leave **~8–11 GB** usable for weights + KV / activations.
+- Metal’s default GPU working set on ≤32–64 GB Macs is often ~**10.5 GB**.
+- Prefer artifacts whose **on-disk size is ≤ ~8 GB**; keep context short unless measured.
+- If a file is **>11 GB**, treat as “does not run” for daily use.
+
+---
+
+## TL;DR
+
+| Question | Short answer |
+| --- | --- |
+| **What is LTX-2.5?** | Open-weights **22B** audio-video DiT (same size class as 2.3) with a **diffusion video decoder**, **Gemma 4 12B** encoder, native **multishot**, auto duration, and a better distilled checkpoint. Released **2026-08-11**. |
+| **Fits this 16 GB M2?** | **No.** Official distilled INT8 transformer is **21.5 GB** *plus* Gemma 4 INT8 **15.4 GB** *plus* VAEs. The encoder alone is the same class as your whole daily LLM. |
+| **Does 2.3 fit instead?** | **Also no for daily use.** Same 22B DiT. 2.3 has a more mature Mac/MLX/Draw Things path and a smaller Gemma **3** encoder zoo (including GGUF), but 16 GB Mac reports are swap hell (~1 min/step). |
+| **Did 2.5 get cheaper to run?** | **No.** Marketing still lists **16 GB NVIDIA VRAM** as the floor. Official docs say **32 GB+ NVIDIA + CUDA 12.7**. 2.5 is a quality/control rewrite, not a RAM-class drop. |
+| **What “16 GB” actually means** | A **discrete NVIDIA 16 GB card** with CPU offload and sequential encoder unload — plus system RAM the GPU does not share. Not 16 GB unified. |
+| **Mac path that works** | **32–48 GB+ Apple Silicon**, MLX or LTX Desktop. Measured 2.5 MLX Q8 peaks at **~23 GB Metal**. LTX Desktop local mode wants **≥15 GB free RAM at launch** and was tested on **M4 Pro 48 GB**. |
+| **On this laptop, use** | LTX **API** / Studio / Comfy Cloud if you want 2.5 output. Keep local video off this machine. Daily drivers stay Gemma 4 12B / Ornith / IndexTTS / ACE-Step. |
+
+**Verdict:** LTX-2.5 is the better *model*. LTX-2.3 is the slightly less-impossible *Mac experiment*. Neither is a daily driver on this M2.
+
+---
+
+## What LTX-2.5 is
+
+LTX-2.5 is Lightricks’ current open world model: a **22B-parameter asymmetric dual-stream diffusion transformer** that generates **synchronized video + 24 kHz stereo audio** in one pass. Workflows: text-to-video, image-to-video, audio-to-video, video-to-video / IC-LoRA edit, first-last-frame, retake, extend, Dub-It. Distilled Fast path is a fixed **8-step** schedule at CFG 1; Pro/dev is the full guided two-stage stack. Output: up to **native 4K HDR**, 24/25/48/50 fps, EXR/ACES.
+
+**License:** [LTX-2.x Community License](https://github.com/Lightricks/LTX-2/blob/main/LICENSE.md) — free commercial use under **$10M ARR**, no mandatory branding; not Apache 2.0. Hugging Face repo is **gated** (agree-to-access). Stock Google Gemma 4 is **not** a substitute: loaders check `gemma4-12b-ltx-v1`.
+
+**Four access paths:** open weights ([HF](https://huggingface.co/Lightricks/LTX-2.5) + [LTX-2](https://github.com/Lightricks/LTX-2) Python), ComfyUI native templates, [LTX Desktop](https://github.com/Lightricks/ltx-desktop), LTX API / Studio.
+
+### What actually changed vs 2.3
+
+Same **22B** class. The upgrade is the stack around the DiT, not a bigger (or smaller) transformer.
+
+| Piece | LTX-2.3 (Mar 2026) | LTX-2.5 (Aug 2026) |
+| --- | --- | --- |
+| **DiT** | 22B audio-video, bundled checkpoint (transformer + VAEs + text projection) | 22B, **split** pack (one file per component). Files **not interchangeable** with 2.3 |
+| **Text encoder** | **Gemma 3 12B** (separate download; GGUF/FP4 exist) | **Custom Gemma 4 12B** + projection bundled. **No GGUF** yet (`gemma4` not in ComfyUI-GGUF `TXT_ARCH_LIST`) |
+| **Decode** | Convolutional / redesigned VAE reconstruction | **Diffusion video decoder** (sharper faces/text, fewer smears; ~**2×** decode cost). Conv VAE still ships as the light fallback |
+| **Shots** | One continuous shot | **Native multishot** — several connected shots, same character/voice/lighting |
+| **Duration** | You pick frame count (`8n+1`) | Optional **duration head** predicts length from the prompt |
+| **Prompting** | Gemma 3 + optional enhancer | Gemma 4 + optional enhancer (~**5 GB** extra; skip on any small box) |
+| **Distilled** | 8-step Fast | Retrained on a larger set **+ RL**; Lightricks’ own artifact table: 2.5 Fast **0.39** vs 2.3 Pro **0.74** (lower = fewer glitches) |
+| **Mac ecosystem** | MLX (`dgrauet/ltx-2-mlx`), Draw Things lists **LTX-2.3**, Comfy MPS anecdotes | MLX conversions exist (PocketAI / `ltx-2-mlx` 2.5 branch) but **32 GB+**; LTX Desktop 1.2 local Fast on Apple Silicon; Draw Things App Store still advertises **2.3** |
+| **LoRAs** | 2.3-trained | Most 2.3 LoRAs/IC-LoRAs **run on 2.5**; a few need revalidation. A LoRA only matches the model it was trained on |
+
+Headline speed (**10 s I2V in 6.8 s**) is **2× GB200** at steady state, 720p. It is a datacenter chart, not an M2 number.
+
+---
+
+## Footprint: files vs this Mac
+
+### Official LTX-2.5 split pack
+
+Sizes from the gated [Lightricks/LTX-2.5](https://huggingface.co/Lightricks/LTX-2.5) tree / community measurements (Aug 2026). Packs differ by a few hundred MB.
+
+| File | Role | On-disk | 16 GB M2 |
+| --- | --- | ---: | --- |
+| `ltx-2.5-22b-*-transformer-bf16.safetensors` | Distilled or dev DiT, BF16 | **~42 GB** | ❌ |
+| `ltx-2.5-22b-distilled-transformer-comfy-int8-convrot.safetensors` | ComfyUI INT8 distilled (official “small” path) | **21.5 GB** | ❌ (>11 GB daily-use line) |
+| `ltx-2.5-22b-distilled-transformer-nvfp4.safetensors` | Distilled NVFP4 (Blackwell / Comfy kernels) | **18.7 GB** | ❌ CUDA/Blackwell, still too big |
+| `gemma4-12b-with-proj-ltx-2.5-bf16.safetensors` | Custom Gemma 4 encoder | **26.3 GB** | ❌ (larger than your Gemma 4 12B Q4 chat model) |
+| `gemma4-12b-with-proj-ltx-2.5-comfy-int8-convrot.safetensors` | Same encoder, Comfy INT8 | **15.4 GB** | ❌ |
+| `gemma4_e2b_it_int8_convrot.safetensors` | Optional prompt enhancer | **~5 GB** | skip |
+| `ltx-2.5-video-vae-bf16.safetensors` | Diffusion VAE (quality) | **~1.47 GB** | would fit *alone* |
+| `ltx-2.5-video-vae-conv-bf16.safetensors` | Conv VAE (faster/lighter) | **~1.45 GB** | would fit *alone* |
+| `ltx-2.5-audio-vae-bf16.safetensors` | Audio VAE + vocoder | **~0.36 GB** | yes |
+| Spatial / temporal upscalers | Two-stage / DFR | **~0.26–1.0 GB** | n/a if the DiT never loads |
+
+**Typical downloads**
+
+| Pack | Disk | Vendor VRAM story |
+| --- | ---: | --- |
+| BF16 distilled split (DiT + Gemma 4 + VAEs + spatial upscaler) | **~66 GiB** | Official docs: **32 GB+ NVIDIA**, CUDA **12.7**, 100 GB disk |
+| Comfy INT8 distilled + INT8 encoder + VAEs | **~38.7 GB** | Community **20–24 GB** NVIDIA |
+| NVFP4 distilled + INT8 encoder + VAEs | **~35.9 GB** | Community **16 GB+ NVIDIA**, Blackwell-shaped |
+| Full BF16 zoo | **~71 GB** | 48–80 GB class |
+
+Official Python (`ltx-pipelines`) wants the **BF16** files; the `*-comfy-int8-convrot` weights are **ComfyUI-only**. FP8-cast + CPU offload is the documented low-VRAM NVIDIA trick, not a Metal recipe.
+
+### Community quants (still not this Mac)
+
+[joeygambino/LTX-2.5-Quantized](https://huggingface.co/joeygambino/LTX-2.5-Quantized) is the honest 16 GB **NVIDIA card** recipe. “Fits 16 GB” assumes **the encoder is not resident during sampling** (Comfy unloads it) and tiled VAE decode.
+
+| Artifact | Size | Notes |
+| --- | ---: | --- |
+| Distilled DiT GGUF Q2_K | **7.9 GB** | Hazy; “12 GB card has nothing else” |
+| Distilled DiT GGUF Q3_K_M | **10.6 GB** | Maintainer’s 16 GB-card floor |
+| Distilled DiT GGUF Q4_K_M | **14.2 GB** | Tight on 16 GB discrete |
+| Distilled DiT Comfy w4a4 / nvfp4 | **11.2 / 12.5 GB** | Comfy-native 4-bit; nvfp4 is Blackwell |
+| Gemma 4 Comfy w4a8 | **10.6 GB** | Smallest *practical* 2.5 encoder in that repo |
+| Gemma 4 nvfp4-torchao (third party) | **~8.9 GB** | Still ~your entire usable pool |
+
+Q3_K_M (10.6) + encoder (10.6) + VAEs (~1.9) is **~23 GB of weights** even if they never sit in Metal together. On a 16 GB *card* that works because system RAM is a second pool. On this Mac there is **one** 16 GB pool, ~**8–11 GB** of it already spoken for.
+
+No IQ2/IQ3/IQ4 GGUF ladder: `llama-quantize` rejects IQ types for this architecture.
+
+### Official LTX-2.3 (for the comparison)
+
+2.3 is a **monolith** (transformer + VAEs + text projection) plus a **separate Gemma 3 12B**.
+
+| File | On-disk | Typical NVIDIA floor |
+| --- | ---: | --- |
+| Distilled BF16 `ltx-2.3-22b-distilled-1.1.safetensors` | **46.1 GB** | 32 GB + offload |
+| Distilled FP8 full checkpoint | **29.5 GB** | often quoted 16–32 GB depending on bundling |
+| Transformer-only FP8 scaled | **~25 GB** | **16 GB NVIDIA** (Ada FP8); the 2.3 “16 GB card” SKU |
+| Gemma 3 12B BF16 | **~24.4 GB** | 32 GB+ |
+| Gemma 3 FP8 / FP4-mixed | **~13.2 / 9.5 GB** | 16–24 GB cards |
+| MLX int4 (`dgrauet/ltx-2.3-mlx-q4`) | **~12 GB** | **16 GB+ unified** (vendor “minimum”) |
+| MLX int8 (`dgrauet/ltx-2.3-mlx-q8`) | **~21 GB** | **32 GB+** |
+| MLX bf16 | **~42 GB** | **64 GB+** |
+
+2.3’s advantage on paper is **Gemma 3 GGUF/FP4** and a finished MLX/Draw Things tree. The DiT is still a 22B video model.
+
+---
+
+## LTX-2.5 vs LTX-2.3 **on this machine**
+
+This is the only comparison that matters for the M2.
+
+| | **LTX-2.3** | **LTX-2.5** |
+| --- | --- | --- |
+| **Daily use on 16 GB M2** | ❌ | ❌ |
+| **Why the weights miss** | Distilled FP8 transformer-only **~25 GB**; MLX q4 **~12 GB** already over the 11 GB line; Gemma 3 FP4 **~9.5 GB** is a second model | Official INT8 DiT **21.5 GB** + Gemma 4 INT8 **15.4 GB**; community Q3 DiT **10.6 GB** still needs a **~9–11 GB** encoder |
+| **Encoder tax** | Gemma **3** — GGUF exists, FP4 mixed ~9.5 GB | Gemma **4** LTX-tuned — **no GGUF**; smallest usable ~**8.9–10.6 GB**. Encoder ≈ your Gemma 4 12B chat weights |
+| **Mac-native runtime** | **Yes, mature:** `dgrauet/ltx-2-mlx` (int4 “16 GB minimum”, `--low-ram` streams q8), Draw Things **LTX-2.3**, Comfy MPS reports | **Younger:** PocketAI MLX Q8 peak **22.89 GB** Metal on an **M5 Max 128 GB**; `ltx-2-mlx` 2.5 branch wants **32 GB+** (24 GB with `--low-ram`). 2.3 MLX runtime **does not** load 2.5 |
+| **LTX Desktop local** | 2.3 Fast still selectable | Default **2.5 Fast**. Mac local mode needs **≥15 GB free RAM at launch** (not 15 GB total). Tested **M4 Pro 48 GB**. This M2 will fall through to **API-only** |
+| **16 GB Mac measured** | M4 Mini **16 GB**: ~**11 GB swap**, **~70 s/step**, ~22 min estimated for 20 steps — operator stopped. ~36 GB Mac: ~**5 min** / 20-step clip | No credible 16 GB unified 2.5 run found. Closest Mac success is **M5 Max 128 GB** (Desktop ~2.5 min for a 5 s Fast clip; MLX Q8 ~93 s at 768×512 / 121 frames) |
+| **Quality if you could run it** | Weaker prompt hold, more artifacts, single shot | Better faces/text/motion, multishot, Gemma 4 adherence — **irrelevant if it will not load** |
+| **Disk to even try** | MLX q4 ~12 GB + Gemma; Comfy 2.3 often 40 GB+ | INT8 pack ~39 GB; BF16 ~66 GB; Desktop tree reported **~97 GB** on M5 Max |
+
+**Read:** 2.5 did **not** make local video available on this laptop. It made local video **better on machines that already had 32–80 GB**. If you were hoping 2.5 was the “now it fits in 16 GB” release, it is the opposite: the new encoder and diffusion decoder add weight and decode cost on top of the same 22B DiT.
+
+The phrase to distrust is Lightricks’ comparison-table **“Min VRAM: 16 GB.”** That cell is **NVIDIA discrete + offload**. Their own open-source docs list **32 GB+ NVIDIA, 32 GB system RAM, CUDA 12.7**. Community “16 GB recipe” for 2.5 is still a **16 GB card**, encoder unloaded, tiled decode.
+
+---
+
+## How it would run (if this were a different Mac)
+
+### Paths that exist, none of them for 16 GB unified
+
+**1) Official Python (`ltx-pipelines`) — CUDA**
+
+```bash
+# Distilled split pack ~66 GiB. CUDA ≥ 12.7. Not Metal.
+uv run python -m ltx_pipelines.distilled \
+  --transformer-path  models/ltx-2.5/diffusion_models/ltx-2.5-22b-distilled-transformer-bf16.safetensors \
+  --text-encoder-path models/ltx-2.5/text_encoders/gemma4-12b-with-proj-ltx-2.5-bf16.safetensors \
+  --video-vae-path    models/ltx-2.5/vae/ltx-2.5-video-vae-bf16.safetensors \
+  --audio-vae-path    models/ltx-2.5/vae/ltx-2.5-audio-vae-bf16.safetensors \
+  --spatial-upsampler-path models/ltx-2.5/latent_upscale_models/ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors \
+  --prompt "..." --output-path out.mp4
+# Low VRAM on NVIDIA: add  --quantization fp8-cast --offload cpu
+```
+
+`natten` (fast diffusion VAE) is **Linux + CUDA only**; macOS falls back to Triton/eager and is slower. Do not install this stack expecting MPS to substitute for CUDA.
+
+**2) ComfyUI native 2.5 templates**
+
+Day-one in ComfyUI ≥ **0.32**. Default files: INT8 distilled DiT **21.5 GB** + Gemma 4 INT8 **15.4 GB** + both VAEs + spatial upscaler. CUDA-first. Comfy-on-Mac MPS for **2.3** already swapped a 16 GB Mini into unusability; 2.5’s encoder is larger and has no GGUF.
+
+**3) MLX (the real Apple path)**
+
+- **2.3:** [dgrauet/ltx-2-mlx](https://github.com/dgrauet/ltx-2-mlx) — `dgrauet/ltx-2.3-mlx-q4` (~12 GB, “16 GB+”), q8 (~21 GB, 32 GB+) with `--low-ram` block streaming. Still treat 16 GB as a **curiosity**, not daily (see Mini swap numbers).
+- **2.5:** [PocketAiHub/LTX-2.5-MLX](https://huggingface.co/PocketAiHub/LTX-2.5-MLX) Q8 **~23 GB peak** Metal for the official 768×512 / 121-frame preset; BF16 smoke **~40 GB** peak at a tiny 384×256 / 17-frame clip. Community launcher gist: **32 GB+** (24 GB with `--low-ram`), ~36 GiB q8 download. Swift MLX port: **32 GB+ recommended**.
+
+**4) LTX Desktop**
+
+Local **2.5 Fast** on Apple Silicon if **≥15 GB RAM is free at launch**. This 16 GB M2 typically has **8–11 GB** usable after macOS — Desktop should stay **API-only** here. Successful local Mac reports are **48–128 GB** machines.
+
+**5) Draw Things**
+
+Native Metal; App Store currently promotes **LTX-2.3**, not 2.5. Independent 2.3 notes put the floor around **M4 Max 48 GB**, not 16 GB M2.
+
+### What a 2.3 MLX “16 GB” try would feel like (do not bother for 2.5)
+
+```bash
+# LTX-2.3 only — documented int4 path. Expect swap, not interactive video.
+ltx-2-mlx generate -p "A cat" --distilled -o cat.mp4 --model dgrauet/ltx-2.3-mlx-q4
+# or stream q8:  --model dgrauet/ltx-2.3-mlx-q8 --low-ram
+```
+
+On an M4 Mini 16 GB this class of Comfy/LTX run hit **~11 GB swap** and **~70 s per denoise step**. An M2 16 GB is not faster. Close the experiment; it is not how you get clips.
+
+---
+
+## Suggested actions on this machine
+
+```
+Want LTX-2.5 quality (multishot, Gemma 4, diffusion decoder)?
+  └─ LTX API / LTX Studio / Comfy Cloud.
+     Do not download the 39–66 GB pack onto this laptop.
+
+Want to run *some* LTX locally "because 16 GB is the listed minimum"?
+  └─ That 16 GB is NVIDIA VRAM + system RAM offload.
+     This Mac is 16 GB unified. Skip.
+
+Want the slightly-more-Mac-native sibling (2.3)?
+  └─ Still not daily use. MLX q4 / Draw Things want 32 GB+ to be sane.
+     16 GB Macs swap. Not worth the disk.
+
+Want local media on this M2 instead?
+  └─ Video: none of the 2026 open DiTs (LTX, Wan, MAGI, JoyAI, MiniMax H3)
+     Audio TTS: IndexTTS 2.5 MLX ~5 GB, Audio8-TTS 0.1B ~1.7 GB
+     Music: ACE-Step 1.5 2B turbo (music report)
+     Chat/code: Gemma 4 12B Q4 / Ornith 1.5 9B Q4
+
+Might 2.5 ever fit here?
+  └─ Only if someone ships a real streaming MLX path whose
+     *peak Metal* stays ≤ ~8–10 GB (not just a 8 GB GGUF on disk).
+     Today's Q8 peak is ~23 GB. Do not wait on this machine.
+```
+
+---
+
+## Sources
+
+- LTX-2.5 product: [ltx.io/model/ltx-2-5](https://ltx.io/model/ltx-2-5)
+- Official facts page: [ltx.io/llm-info](https://ltx.io/llm-info)
+- Open-source minimums: [docs.ltx.io system requirements](https://docs.ltx.io/open-source-model/getting-started/system-requirements.md) (32 GB+ NVIDIA, CUDA 12.7)
+- Weights: [Lightricks/LTX-2.5](https://huggingface.co/Lightricks/LTX-2.5), [Lightricks/LTX-2.3](https://huggingface.co/Lightricks/LTX-2.3)
+- Code: [Lightricks/LTX-2](https://github.com/Lightricks/LTX-2) (2.5 split pack; [MODELS-LTX-2.3.md](https://github.com/Lightricks/LTX-2/blob/main/MODELS-LTX-2.3.md) for the monolith)
+- ComfyUI 2.5: [docs.comfy.org LTX-2.5](https://docs.comfy.org/tutorials/video/ltx/ltx-2-5)
+- Desktop: [Lightricks/ltx-desktop](https://github.com/Lightricks/ltx-desktop) (Mac local: ≥15 GB *free* RAM; tested M4 Pro 48 GB)
+- 2.3 MLX: [dgrauet/ltx-2-mlx](https://github.com/dgrauet/ltx-2-mlx)
+- 2.5 MLX: [PocketAiHub/LTX-2.5-MLX](https://huggingface.co/PocketAiHub/LTX-2.5-MLX)
+- 16 GB NVIDIA quants: [joeygambino/LTX-2.5-Quantized](https://huggingface.co/joeygambino/LTX-2.5-Quantized)
+- 2.3 VRAM SKUs: [ltxworkflow.com VRAM guide](https://ltxworkflow.com/guide/vram-requirements)
+- 16 GB Mac swap (2.3-class Comfy): [LTX Video Mac vs Nvidia](https://www.youtube.com/watch?v=A0FSyx2E5tI)
+- Prior one-line 2.5 ruling: [report-2026-08-16-video-ai-news.md](./report-2026-08-16-video-ai-news.md)
+
+## Method / caveats
+
+- Hardware bar matches prior reports in this folder (16 GB M2 usable ~**8–11 GB**; files **>11 GB** = not daily use).
+- File sizes from Hugging Face / Lightricks docs / joeygambino measurements as of **2026-08-25**. Packs differ by a few hundred MB.
+- Speed and artifact numbers are **vendor charts** (2× GB200, fal.run API, automated glitch scoring). This report did not re-benchmark on the M2.
+- “Open weights” ≠ “runs on a laptop.” 2.5’s 16 GB marketing floor is a **discrete GPU** story with offload; official OSS docs start at **32 GB NVIDIA**.
+- MLX/Desktop Mac successes cited are **48–128 GB** machines. Treat “16 GB minimum” MLX int4 as a load flag, not a usable workflow on this M2.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a dedicated 16 GB M2 MacBook Pro runnability note for **LTX-2.5**, with the requested side-by-side against **LTX-2.3**. Same hardware bar and report series as the July–August local-model notes.

## Verdict on this machine

- **LTX-2.5 does not run** as a daily driver. Official distilled INT8 transformer is 21.5 GB plus a Gemma 4 12B encoder at 15.4 GB INT8 — the encoder alone is the same class as the daily Gemma 4 12B chat model. Marketing “min 16 GB VRAM” is a discrete NVIDIA + offload floor; official OSS docs start at 32 GB+ NVIDIA / CUDA 12.7. Measured MLX Q8 peaks at ~23 GB Metal.
- **LTX-2.3 also does not run** as daily use (same 22B DiT). It only has a more mature Mac path (MLX q4, Draw Things, Gemma 3 GGUF). 16 GB Mac reports are swap hell (~70 s/step).
- 2.5 is a **quality/control rewrite** (diffusion decoder, Gemma 4, native multishot), not a RAM-class drop.

Use LTX API / Studio if you want 2.5 output. Keep IndexTTS / ACE-Step / Gemma 4 12B / Ornith as the local stack.

Report: `researches/local_model_reports/report-2026-08-25-ltx-2.5.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79a427cc-46a5-4465-8405-489ad199c6be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79a427cc-46a5-4465-8405-489ad199c6be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

