### PR TITLE
Local model reports: LLM shortlist for 16GB M2 (Jul–Aug 2026)

### DIFF
--- a/researches/local_model_reports/README.md
+++ b/researches/local_model_reports/README.md
@@ -9,6 +9,7 @@ Shared hardware note: [Your real memory budget](./memory-budget.md).
 | Report | Window | Focus |
 | --- | --- | --- |
 | [report-2026-07-17.md](./report-2026-07-17.md) | mid-May → mid-July 2026 | LLMs that fit a 16 GB M2 MacBook Pro, vs Gemma 4 12B Unified |
+| [report-2026-08-31.md](./report-2026-08-31.md) | mid-July → late August 2026 | Sequel shortlist vs Gemma 4 12B Unified: Ling-3.0-tiny, Ornith 1.5 9B, Bonsai 27B |
 | [report-2026-07-27-music.md](./report-2026-07-27-music.md) | as of 2026-07-27 | Local **music generation**: clip vs song, streaming, VRAM, Mac fit, vs LLMs; cites r/LocalLLaMA & r/StableDiffusion |
 | [report-2026-08-02-video-ai-news.md](./report-2026-08-02-video-ai-news.md) | video [OrcBSpADCGk](https://youtu.be/OrcBSpADCGk) (as of 2026-08-02) | Runnability on 16 GB M2 for every model named in that AI-news video; deep dive on CrisperWhisper + Instella |
 | [report-2026-08-16-video-ai-news.md](./report-2026-08-16-video-ai-news.md) | video [62HSUsS0ypo](https://www.youtube.com/watch?v=62HSUsS0ypo) (as of 2026-08-16) | Runnability on 16 GB M2 for every model named in that AI-news video; IndexTTS 2.5 + Qwen3.8-27B vs the rest |

--- a/researches/local_model_reports/report-2026-08-31.md
+++ b/researches/local_model_reports/report-2026-08-31.md
@@ -1,0 +1,311 @@
+# Notable Local Models You Can Run on a 16GB M2 MacBook Pro
+
+**Window:** mid-July → late August 2026  
+**Compiled:** 2026-08-30  
+**Hardware target:** Apple **M2 MacBook Pro, 16 GB unified memory**  
+**Stack assumption:** Metal / MLX / llama.cpp / Ollama / PyTorch-MPS — **no CUDA**  
+**Source:** [r/LocalLLaMA](https://www.reddit.com/r/LocalLLaMA/), filtered to releases that actually fit this machine  
+**Memory budget:** [Your real memory budget](./memory-budget.md)  
+**Previous shortlist:** [report-2026-07-17.md](./report-2026-07-17.md) (mid-May → mid-July)
+
+## TL;DR
+
+| Verdict | Models |
+| --- | --- |
+| **Runs well on this Mac** | **Ling-3.0-tiny** Q4 (~4.8 GB; 7.9B / 1.3B-A MoE) · **Ornith 1.5 9B** Q4–Q6 (~5.6–8.5 GB) · **Bonsai 27B** 1-bit MLX (~3.9–5.1 GB) · **LFM2.5-2.6B** / **LFM2.5-VL-3B** Q4 (~1.7 GB) · **North-Micro-Vision-Instruct** 2.4B · **Gemma 4 12B Unified** Q4 (still the multimodal default) |
+| **Tight / experimental** | **Mach-1 Additive 35B** via `mach-engine` (~8.1 GB; vendor “fits 16 GB Macs”) · **Maple-Preview** 20B-A1B ternary (~5.3 GB; custom Apple runtime, not stock llama.cpp) · **Qwen3.8-27B** at **IQ2 / Q2 only** (~9 GB) · **Apertus-v1.5 8B** (size OK; official GGUF still immature) · **Instella-MoE-16B-A3B** Q2–Q3 (see [Aug 2 video report](./report-2026-08-02-video-ai-news.md)) |
+| **Same size, better tools** | Community **Gemma 4 12B** tool-calling finetunes (Coding-Monkey / agentic v2) — same Q4 ~6.7–6.9 GB as the baseline |
+| **Specialists, not chat** | **nl2sh / ShellWhisperer 1.5B** (~1 GB) · **Inflect v2** TTS (16–38 MB) · **Granite Speech 5.0 Turbo CTC** (470M) · **Luth-2** 0.8B / 2B (French) · **Breeze-TTS-2** (~7 GB) |
+| **Headline of the window, not this machine** | **Qwen3.8-27B** Q4 (~17 GB; Unsloth’s “17 GB VRAM” is a **24 GB** story) · Qwen3.8-2.4T · GLM-5.3 / 5.3-Flash · DeepSeek-V4-Flash/Pro · Kimi K3 · Nemotron 3.5 Lightning · Ornith 1.5 **35B / 397B** · Ling-3.0-**flash** · Thomson-1.0-Small |
+
+This window’s actual laptop pickup is **Ling-3.0-tiny**: a 1.3B-active MoE that llama.cpp merged on **2026-08-17**, InclusionAI measured on Apple Silicon, and a 4 GB-VRAM owner called “as smart as Qwen 3.5 9B / Gemma 12, and faster.” **Ornith 1.5 9B** is the coding upgrade over Ornith 1.0 from the previous report. **Bonsai 27B** is the new “27B-class in 4 GB” path — custom 1-bit MLX kernels, not a drop-in Ollama tag. Keep **Gemma 4 12B Unified** when you need native image + audio in one file.
+
+---
+
+## Comparison vs Gemma 4 12B Unified (encoder-free)
+
+**Baseline (unchanged):** [google/gemma-4-12B](https://huggingface.co/google/gemma-4-12B) — **12B Unified**, no separate vision/audio encoders. ~**11.95B** params, **256K** context, **Apache 2.0**, text + image + audio. Q4 ~**6.7 GB**. On this M2 it is still the only mid-size option with **native audio in**.
+
+### Specs side-by-side
+
+| | **Gemma 4 12B Unified** | **Ornith 1.5 9B** | **Ling-3.0-tiny** | **Bonsai 27B** (1-bit) | **LFM2.5-2.6B** |
+| --- | --- | --- | --- | --- | --- |
+| **Params** | 11.95B dense | ~9B dense (+ optional mmproj) | **7.9B / 1.3B-A** MoE | 27B binary (from Qwen3.6-27B) | 2.69B hybrid |
+| **Modalities** | Text + image + audio (+ video frames) | Text (+ image if you load mmproj) | Text | Text + image (optional 0.63 GB tower) | Text (VL sibling is 3B) |
+| **Encoders** | **None** (unified) | optional vision projector | n/a | HQQ 4-bit vision, off by default | n/a / SigLIP2 on VL-3B |
+| **Context (native)** | 256K | 256K-class | 131K (YaRN → 256K) | 262K (hybrid attention) | 128K |
+| **License** | Apache 2.0 | MIT | MIT | Apache 2.0 | LFM / check card |
+| **Q4 / packed footprint** | ~**6.7 GB** | Q4_K_M ~**5.6–5.9 GB** | Q4_K_M ~**4.8 GB** | 1-bit ~**3.9 GB** (MLX pack **5.13 GB**) | Q4_K_M ~**1.67 GB** |
+| **16 GB M2 fit** | Yes, keep context modest | Comfortable at Q4–Q6 | Comfortable; more RAM left for IDE | Comfortable at 4K–10K; 100K needs the 4-bit KV | Very comfortable |
+| **CUDA?** | No — Metal / MLX | Metal llama.cpp | Metal llama.cpp (`bailingmoe3`, ≥ 2026-08-17) | **MLX / llama.cpp fork** (not stock Ollama) | Official **MLX** + GGUF |
+| **Tok/s (order of mag.)** | Community ~**30–50** on M2/M3 at Q4 | Similar 9B class; M2 slower than M4 | Vendor **86–90** on **M4 Pro** FP8 @ ~8.3 GiB; M2 slower, still MoE-fast | Vendor **26** on M4 Pro / **44** on M5 Pro Metal; M2 below that | Vendor **220** on M5 Max; phone **30**; M2 still “instant” |
+
+**Mach-1 Additive 35B** is a sixth lane: packed Qwen3.6-35B-A3B at ~**8.1 GB**, Metal via [`mach-engine`](https://pypi.org/project/mach-engine/) (vendor: “fits 16 GB Macs”). Not in the table because it is **not** GGUF/Ollama.
+
+### Quality (published / vendor tables — not identical harnesses)
+
+Coding rows for Ornith are from the [Ornith 1.5 card](https://ornith.ai/ornith_1_5.html) (same table still lists Ornith 1.0 and Qwen3.5-9B). Gemma reasoning/vision numbers are Google’s card from the previous report. Qwen3.8-27B numbers are Alibaba’s card — included so you can see what you are **not** running at Q4.
+
+| Task | Gemma 4 12B Unified | Ornith 1.5 9B | Ornith 1.0 9B | Qwen3.5-9B | Qwen3.8-27B (does **not** fit Q4) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| **SWE-bench Verified** | 44.2 | **70.6** | 69.4 | 53.2 | — |
+| **SWE-bench Pro** | 27.6 | **47.5** | 42.9 | 31.3 | **61.7** (vendor) |
+| **Terminal-Bench 2.1** | 21.0 | **46.2** | 43.1 | 21.3 | **73.0** (vendor) |
+| **NL2Repo** | 10.3 | **32.4** | 27.2 | 16.2 | 42.3 (vendor) |
+| **GPQA Diamond** | **78.8%** (Gemma card) | 86.4 (Ornith card) | 82.5 | 81.7 | **89.2** (vendor) |
+| **LiveCodeBench v6** | **72.0%** (Gemma card) | — | — | — | **90.3** (vendor) |
+| **MMMU Pro** (vision) | **69.1%** | n/a unless mmproj | n/a | weaker / no audio | native image/video; not this Mac at Q4 |
+
+Ling-3.0-tiny publishes **AA Intelligence Index 25** / **Agentic Index 16**, not the Ornith SWE table. InclusionAI positions it between 4B and 8–12B Qwen/Gemma; a LocalLLaMA owner with **4 GB VRAM** called it “very close” to Qwen 3.5 9B / Gemma 12 at **36 tok/s** vs ~5 tok/s for the dense 9B. Treat that as a speed story first.
+
+Bonsai’s own 15-bench thinking average: **76.11** for 1-bit (89.5% of Qwen3.6-27B FP16) vs **80.49** ternary. Math holds (AIME26 **87.08**); agentic coding is explicitly **not** a strong target of this release.
+
+### Who wins what on your M2
+
+| Goal | Pick | Why |
+| --- | --- | --- |
+| **Screenshots / PDFs / voice in one model** | **Gemma 4 12B Unified** | Still the only mid-size native text+image+**audio** with no encoder tax |
+| **Repo coding / terminal agents** | **Ornith 1.5 9B** | Small bump over 1.0; still a large gap vs Gemma 12B on SWE / Terminal-Bench |
+| **Fast general chat, max headroom** | **Ling-3.0-tiny** Q4 | 1.3B active, ~4.8 GB, stock llama.cpp as of 2026-08-17 |
+| **27B-class reasoning in ~4 GB** | **Bonsai 27B** 1-bit | Custom MLX/llama.cpp kernels; keep ternary (~6–7 GB) if quality > phone-size |
+| **Tiny tool-calling / RAG loops** | **LFM2.5-2.6B** | Official MLX; 128K; not a Gemma/Ornith replacement |
+| **Docs / charts / OCR without Gemma** | **LFM2.5-VL-3B** or **North-Micro-Vision-Instruct** | 2–3B VLMs; Gemma still wins if you already run it |
+| **35B-teacher retention in ~8 GB** | **Mach-1 Additive** | Metal `mach-engine` only; GGUF fork is CUDA/Vulkan (CPU on Mac) |
+| **Best single default if you want one file** | **Gemma 4 12B** *or* **Ornith 1.5 9B** *or* **Ling-3.0-tiny** | Gemma if multimodal daily; Ornith if you code locally; Ling if you want speed + RAM left |
+
+**Practical M2 note:** Qwen3.8-27B is the community’s “Opus at home” headline this window. Unsloth’s **17 GB** figure is **4-bit on a 24 GB class machine**. On 16 GB unified, only IQ2/Q2 (~9 GB) even *loads*, and that is a curiosity — same verdict as the [Aug 16 video report](./report-2026-08-16-video-ai-news.md).
+
+---
+
+## Start here
+
+| Role | Model | Quant | Footprint | Notes |
+| --- | --- | --- | --- | --- |
+| **Multimodal daily driver** | **Gemma 4 12B Unified** | Q4 | ~**6.7 GB** | Unchanged; still encoder-free text/image/audio |
+| **Coding daily driver** | **Ornith 1.5 9B** | Q4_K_M | ~**5.6–5.9 GB** | Upgrade from Ornith 1.0; skip 35B/397B |
+| **Fast lean generalist** | **Ling-3.0-tiny** | Q4_K_M | ~**4.8 GB** | New pickup; llama.cpp `bailingmoe3` |
+| **27B-in-4GB experiment** | **Bonsai 27B** | 1-bit MLX / Q1_0 | ~**3.9–5.1 GB** | PrismML kernels; ternary if you have ~7 GB |
+| **Tiny agent** | **LFM2.5-2.6B** | Q4_K_M | ~**1.67 GB** | Replaces Agents-A1-4B in the “leave RAM for the IDE” slot |
+| **Docs / OCR specialist** | LFM2.5-VL-3B or North-Micro-Vision | Q4 | ~**1.6–3 GB** | Not a chat replacement |
+| **nl→bash** | **nl2sh-1.5B** | Q4_K_M | **941 MB** | One command, ~1 s on a laptop CPU |
+| **TTS / ASR add-ons** | Inflect v2 · Granite Speech 5.0 Turbo CTC | n/a | **MB–hundreds of MB** | Gemma still does speech-*in* |
+
+---
+
+## Chat & coding models
+
+### Ling-3.0-tiny (InclusionAI / Ant Group) — **recommended new pickup**
+
+Released ~2026-08-10; llama.cpp **`bailingmoe3`** merged **2026-08-17** ([PR #26608](https://github.com/ggml-org/llama.cpp/commit/373336672029b12e09f272bc027cc801345a3fd6)). High-engagement follow-up: [Ling 3.0 Tiny is the strongest, fastest… on my low end PC](https://www.reddit.com/r/LocalLLaMA/comments/1vqx6nd/ling_30_tiny_is_the_strongest_fastest_and/).
+
+| | |
+| --- | --- |
+| **Size** | **7.9B total / 1.3B active** (128 routed experts, 8 + 1 shared) |
+| **Arch** | 3:1 KDA + MLA; hybrid reasoning (`enable_thinking`) |
+| **License** | MIT |
+| **CUDA?** | No — Metal llama.cpp. Ollama MLX path exists as **PR #17643**, not a stock tag yet |
+| **Memory** | Q4_K_M ~**4.82 GB** · Q5 ~**5.6** · Q6 ~**6.5** · Q8 ~**8.4**. Vendor FP8 peak **~8.34 GiB** at 8K on Apple Silicon |
+| **Context** | Keep **≤8K–16K** on this M2; native 131K |
+| **Throughput** | **86–90 tok/s** claimed on **M4 Pro** FP8. M2 will be slower; community 4 GB NVIDIA report **~36 tok/s** vs ~5 for dense 9B |
+| **vs Gemma 12B** | Text-only; much faster; no native audio/vision. Quality: “between 4B and 8–12B” per the HF thread, not Ornith-level coding |
+
+```bash
+llama-server -hf bloomer010/Ling-3.0-tiny-GGUF:Q4_K_M -c 8192 --jinja \
+  --temp 1.0 --top-p 0.95 --top-k 20
+```
+
+HF: [inclusionAI/Ling-3.0-tiny](https://huggingface.co/inclusionAI/Ling-3.0-tiny) · GGUF: [bloomer010/Ling-3.0-tiny-GGUF](https://huggingface.co/bloomer010/Ling-3.0-tiny-GGUF)
+
+**Skip:** Ling-3.0-**flash** (124B / 5.1B-A) — Q4_K_M ~**78 GB**.
+
+---
+
+### Ornith 1.5 9B (ornith-ai / DeepReinforce) — **coding pick, v1.0 successor**
+
+Released ~2026-08-19. Same memory class as Ornith 1.0 from the May–Jul report. Use the **9B dense** only.
+
+| | |
+| --- | --- |
+| **Size** | ~9B dense (+ ~0.46B vision if you load mmproj) |
+| **License** | MIT |
+| **CUDA?** | No — Metal llama.cpp (`qwen35` arch; recent build) |
+| **Memory** | Q4_K_M ~**5.6–5.9 GB** · Q5 ~**6.5** · Q6 ~**7.4** · Q8 ~**9.5** (tight). AtomicChat 16 GB Mac row: AD-Q8_0-Q6_K ~**8.6 GB** if apps are closed |
+| **Context** | Keep **≤8K** for comfort; raise only after measuring |
+| **vs Gemma 12B** | Still much stronger SWE / Terminal-Bench. Optional vision; **no** native audio |
+| **vs Ornith 1.0** | SWE-Verified **70.6** vs **69.4**; SWE-Pro **47.5** vs **42.9**; Terminal-Bench 2.1 **46.2** vs **43.1** |
+
+```bash
+llama-server -hf bartowski/Ornith-1.5-9B-GGUF:Q4_K_M -c 8192
+```
+
+HF: [ornith-ai/Ornith-1.5-9B](https://huggingface.co/ornith-ai/Ornith-1.5-9B) · GGUF: [bartowski/Ornith-1.5-9B-GGUF](https://huggingface.co/bartowski/Ornith-1.5-9B-GGUF)  
+Also covered in [report-2026-08-23-video-ai-news.md](./report-2026-08-23-video-ai-news.md).
+
+---
+
+### Bonsai 27B (PrismML) — **1-bit 27B that actually fits**
+
+Posted ~2026-07-17 ([Bonsai 27B runs locally on an iPhone](https://www.reddit.com/r/LocalLLaMA/comments/1uyz9n2/bonsai_27b_runs_locally_on_an_iphone_a_27b_model/)). Derived from **Qwen3.6-27B**, not Qwen3.8.
+
+| | |
+| --- | --- |
+| **Size** | 27B binary g128 (1.125 bpw) or ternary (1.71 bpw) |
+| **License** | Apache 2.0 |
+| **CUDA?** | Custom **MLX** (Python/Swift) and llama.cpp **fork**. Stock Ollama will not load the 1-bit kernels |
+| **Memory** | 1-bit ~**3.9 GB** native / MLX pack **5.13 GB**. Peak ~**5.9 GB** at 4K (MLX). Ternary ~**5.9–7.2 GB** |
+| **Throughput** | Vendor Metal: **26 tok/s M4 Pro**, **44 M5 Pro**, **66 M5 Max**. Expect **low/mid tens** on M2 |
+| **vs Gemma 12B** | Much larger teacher, compressed. Stronger math/coding retention than a random IQ2 27B. **Weaker long-horizon agentic coding** than Ornith 9B (vendor says that is next). Vision optional |
+
+Prefer **ternary** on this laptop if the extra ~2 GB is free; prefer **1-bit** if Cursor + browser must stay open. Do not enable the DSpark drafter on Apple Silicon by default (vendor: verification does not amortize at batch-1).
+
+HF: [prism-ml/Bonsai-27B-mlx-1bit](https://huggingface.co/prism-ml/Bonsai-27B-mlx-1bit) · GGUF: [prism-ml/Bonsai-27B-gguf](https://huggingface.co/prism-ml/Bonsai-27B-gguf) · ternary: [prism-ml/Ternary-Bonsai-27B-gguf](https://huggingface.co/prism-ml/Ternary-Bonsai-27B-gguf)
+
+---
+
+### Mach-1 Additive 35B (Syzygy Research) — **tight, Metal-native pack**
+
+Community spike ~2026-08-04. Packed **Qwen3.6-35B-A3B** at ~1.7 bpw; vendor mean retention **96.3%** across 12 benches vs the BF16 teacher.
+
+| | |
+| --- | --- |
+| **Memory** | Text ~**8.1 GB**; multimodal sibling ~**9.0 GB** |
+| **16 GB M2 fit** | Vendor: **yes**. Lives in the 6–9 GB “OK with 4K–8K” band — close apps |
+| **Mac path** | [`mach-engine`](https://pypi.org/project/mach-engine/) (`pip install mach-engine`; Python 3.12+). GGUF exists only in a **Mach-1 llama.cpp fork**; that card says Apple Silicon GGUF runs **on CPU** — use Mach Studio / `mach-engine` for Metal |
+| **vs Gemma 12B** | Teacher is a 35B MoE. Not a multimodal daily driver unless you take the 9 GB pack. Custom stack, not Ollama |
+
+```bash
+mach generate SyzygyResearch/Mach-1-Additive-35B -p "Write a binary search in Python."
+# or: mach serve SyzygyResearch/Mach-1-Additive-35B
+```
+
+HF: [SyzygyResearch/Mach-1-Additive-35B](https://huggingface.co/SyzygyResearch/Mach-1-Additive-35B)
+
+---
+
+### LFM2.5-2.6B and LFM2.5-VL-3B (Liquid AI) — **tiny agent / tiny VLM**
+
+Released ~2026-08-04 / 2026-08-12. Official GGUF + **MLX**.
+
+| | **2.6B** | **VL-3B** |
+| --- | --- | --- |
+| **Job** | Tool-calling / RAG / extraction, 128K | Image + text; OCR / grounding |
+| **On-disk Q4** | ~**1.67 GB** | Q4_0 ~**1.59 GB** / Q4_K_M ~**1.67 GB** |
+| **16 GB M2** | Trivial | Trivial |
+| **Mac path** | `LiquidAI/LFM2.5-2.6B-MLX` or GGUF | llama.cpp `/image` + GGUF |
+| **vs Gemma 12B** | Far less general knowledge; wins on latency and RAM left over | No audio; use when Gemma is too heavy for a vision-only sidecar |
+
+Vendor decode: **220 tok/s** on M5 Max, **30 tok/s** on a phone, under **2.5 GB**. Liquid’s own card says **not** for agentic coding or knowledge-heavy tasks.
+
+HF: [LiquidAI/LFM2.5-2.6B](https://huggingface.co/LiquidAI/LFM2.5-2.6B) · [LiquidAI/LFM2.5-VL-3B](https://huggingface.co/LiquidAI/LFM2.5-VL-3B)
+
+---
+
+### Gemma 4 12B Unified — **still the multimodal baseline**
+
+Unchanged from [report-2026-07-17](./report-2026-07-17.md). Q4 ~**6.7 GB**. This window added **community tool-calling finetunes** at the same footprint:
+
+- [TheOneWhoWill/Coding-Monkey-Gemma-GGUF](https://huggingface.co/TheOneWhoWill/Coding-Monkey-Gemma-GGUF) — held-out exact tool-call **71%** vs **26.5%** base (author’s 102-prompt set), posted because “I can’t fit anything else comfortably into my 16 GBs”
+- [ludx/gemma-4-12B-agentic-fable5-composer2.5-v2-3.5x-tau2](https://huggingface.co/ludx/gemma-4-12B-agentic-fable5-composer2.5-v2-3.5x-tau2) — Q4_K_M **6.87 GB**; tau2-bench telecom agentic upgrade
+
+These do **not** replace Ornith on SWE tables. They are “keep Gemma, make tools less broken.”
+
+---
+
+### Qwen3.8-27B (Alibaba) — **headline, not a daily driver here**
+
+Released 2026-08-14. Dense VLM, Apache 2.0, 256K, native image/video. Unsloth: 4-bit **16–19 GB** total memory; Q4_K_M file **~17.1 GB**. IQ2_XXS **~9 GB**.
+
+| | |
+| --- | --- |
+| **16 GB M2 fit** | **No** at Q4. **⚠️** IQ2/Q2 only, short context, apps closed — same “curiosity” verdict as the Aug 16 video report |
+| **vs Gemma 12B** | Vendor coding/reasoning numbers crush 12B. Irrelevant if the file is 17 GB |
+
+If you ever move to a **24 GB+** Mac, this is the 27B to run. Until then, Bonsai (1-bit of **3.6**-27B) is the 27B-class artifact that fits.
+
+HF: [Qwen/Qwen3.8-27B](https://huggingface.co/Qwen/Qwen3.8-27B) · GGUF: [unsloth/Qwen3.8-27B-GGUF](https://huggingface.co/unsloth/Qwen3.8-27B-GGUF)
+
+---
+
+### Maple-Preview (DeepGrove) — **ternary 20B-A1B, custom Mac runtime**
+
+~**5.31 GB** checkpoint, MIT, 131K, 256-expert MoE (~1B active). Vendor: **218 tok/s** on a **Mac mini M4** via a **separate on-device runtime**. Hugging Face Transformers path is **Triton / FlashAttention / CUDA**. GGUF needs a fork (`tq2_0`); community CUDA patches are not Metal.
+
+Treat as **experimental** on this M2 until the Apple runtime is something you can install without a research checkout. Reasoning-focused preview; vendor says agentic post-training is thin.
+
+HF: [deepgrove/maple-preview](https://huggingface.co/deepgrove/maple-preview)
+
+---
+
+### Apertus-v1.5 8B (Swiss AI) — **size fits, tooling lags**
+
+Apache 2.0 + AUP, multilingual, 262K, 8B (+ 70B sibling). Q4 would be a comfortable ~5 GB **if** you had a boring GGUF. Official multimodal arch was **not** in llama.cpp at release; community text-only conversions exist ([andreasmartin/apertus-v1.5-8b-text](https://huggingface.co/andreasmartin/apertus-v1.5-8b-text)). Niche vs Gemma/Ling unless you need the open-data Swiss stack.
+
+---
+
+### AMD Instella-MoE-16B-A3B
+
+Still the experimental 16B/2.8B-A MoE from late July. ResearchRAIL weights; Q2–Q3 + non-mainline llama.cpp. Details: [report-2026-08-02-video-ai-news.md](./report-2026-08-02-video-ai-news.md).
+
+---
+
+## Specialists (not full LLM substitutes)
+
+| Model | Job | vs Gemma 12B / prior shortlist |
+| --- | --- | --- |
+| **nl2sh-1.5B** ([ThorOdinson246](https://huggingface.co/ThorOdinson246/nl2sh-1.5b-Q4_K_M)) | Natural language → one bash line | **941 MB**, ~1 s on laptop CPU. InterCode-ALFA **0.620** vs GPT-4o 0.73. Not a chat model. Related: [fableforge-ai/ShellWhisperer-1.5B](https://huggingface.co/fableforge-ai/ShellWhisperer-1.5B) |
+| **Inflect v2** Nano/Micro | Fixed-voice English TTS | **16 / 38 MB** FP32. Replaces Inflect-Nano from the May–Jul list. No cloning, one male voice |
+| **Granite Speech 5.0 Turbo CTC** | Fast ASR, **470M**, no LLM backbone | Speech-*in* sidecar; Gemma already does audio. IBM: laptop/phone class |
+| **Breeze-TTS-2** | Community “frontier TTS” | Author: **~7 GB** local — OK if nothing else is loaded |
+| **Luth-2** 0.8B / 2B | French SOTA SLMs (Qwen3.5 post-train) | Same niche as Amalia 9B was for Portuguese — language, not coding |
+| **North-Micro-Vision-Instruct** | 2.4B native-res document VLM | Apache 2.0; DocVQA-class OCR. BF16 ~5 GB; Q4 should be easy. No tool calling |
+| **LFM2.5-VL-3B** | Tiny VLM / OCR | Official GGUF; see above |
+| **IndexTTS 2.5 / Audio8-TTS** | Voice clone TTS | Already in [Aug 16](./report-2026-08-16-video-ai-news.md) / [Aug 23](./report-2026-08-23-video-ai-news.md) video reports — not new LocalLLaMA-first this window |
+| **Aurora-80K / 60 MB from-scratch toys** | Research / demos | Fun; not assistants |
+
+---
+
+## What this window hyped that does **not** fit
+
+| Model | Why not |
+| --- | --- |
+| **Qwen3.8-27B** Q4 / UD-Q4 | **~17 GB** file; Unsloth 4-bit wants **16–19 GB** *plus* OS |
+| **Qwen3.8-2.4T-A95B / Max** | Terabyte class |
+| **GLM-5.3 / GLM-5.3-Flash** | 1-bit still **~100–217 GB** — [Aug 30 video report](./report-2026-08-30-video-ai-news.md) |
+| **DeepSeek-V4-Flash / Pro, Kimi K3** | Hundreds of GB even quantized |
+| **Nemotron 3.5 Lightning 30B-A3B** | Smallest Unsloth GGUF ~**19 GB** |
+| **Thomson-1.0-Small** | Name says small; it is **35B MoE**, Q4_K_M **~21 GB** |
+| **Ornith 1.5 35B-A3B / 397B** | Q4 ~**21 GB** / multi-accelerator |
+| **Ling-3.0-flash** | Q4 ~**78 GB** |
+| **MiniMax-H3 / Music 3 / video DiTs** | CUDA / 24 GB+; see music and video reports |
+| **dots3-note-prev** | **280B / 16B-A** |
+
+---
+
+## Quant / runtime cheat sheet (M2 16 GB)
+
+| On-disk size | Verdict |
+| --- | --- |
+| ≤ 6 GB | Comfortable (Ling Q4, Ornith Q4, Bonsai 1-bit, LFM2.5) |
+| 6–9 GB | OK with **4K–8K** (Gemma Q4, Mach-1, Bonsai ternary, Ornith Q6) |
+| 9–11 GB | Fragile (Qwen3.8-27B IQ2 lives here) |
+| &gt; 11 GB | Skip for daily use |
+
+**Preferred stack:** Ollama / LM Studio (Metal) or **MLX** when official. Ling and Ornith: **recent llama.cpp**. Bonsai: **PrismML MLX or llama.cpp fork**. Mach-1: **`mach-engine`**, not stock GGUF. Avoid CUDA-only NVFP4 server recipes.
+
+---
+
+## Method / caveats
+
+- Shortlist = r/LocalLLaMA **2026-07-17 → 2026-08-31** “New Model” threads (min score 50), kept only if the artifact can live in ~**8–11 GB** usable on a 16 GB M2. **Gemma 4 12B Unified** stays the comparison baseline so this note is a sequel to [report-2026-07-17.md](./report-2026-07-17.md).
+- Hardware bar: [memory-budget.md](./memory-budget.md).
+- Coding numbers: Ornith 1.5 card vs Ornith 1.0 / Qwen3.5-9B / Gemma 4-31B (not 12B) on several rows. Gemma 12B reasoning/vision: Google card. Qwen3.8-27B: Alibaba card. **Not** one harness.
+- Tok/s figures are **vendor or community**, not re-benchmarked on this M2. M2 is slower than the M4/M5 numbers quoted for Ling, Bonsai, and LFM2.5.
+- Video-report overlap: Qwen3.8-27B and Instella (Aug 2 / Aug 16), Ornith 1.5 (Aug 23), GLM-5.3 (Aug 30). Those notes stay the deep dives for video-named models; this file is the **LocalLLaMA LLM shortlist**.
+- Archive fetch helper: [`fetch_localllama_posts.py`](./scripts/fetch_localllama_posts.py)
+
+```bash
+python3 scripts/fetch_localllama_posts.py \
+  --after 2026-07-17 --before 2026-08-31 \
+  --new-model-only --min-score 50 \
+  --out posts.jsonl
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sequel to the [May–Jul 2026 LocalLLaMA shortlist](researches/local_model_reports/report-2026-07-17.md), covering **mid-July through late August 2026**, scoped to models that can run on a **16GB M2 MacBook Pro**.

Written in the later reports’ format: link to `memory-budget.md`, TL;DR verdict table, then Gemma 4 12B Unified as the comparison baseline.

**Takeaway:** pick **Ling-3.0-tiny** for speed and RAM headroom; **Ornith 1.5 9B** as the coding upgrade over 1.0; **Bonsai 27B** 1-bit if you want 27B-class reasoning in ~4 GB (custom MLX kernels); keep **Gemma 4 12B Unified** for native image + audio. **Qwen3.8-27B** is this window’s headline and still does **not** fit at Q4.

Fetched via `fetch_localllama_posts.py --after 2026-07-17 --before 2026-08-31 --new-model-only --min-score 50`.

## Files

- `researches/local_model_reports/report-2026-08-31.md`
- `researches/local_model_reports/README.md` (index row)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d1c6ba0-b04d-4fd4-9087-f20240e4790e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d1c6ba0-b04d-4fd4-9087-f20240e4790e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

